### PR TITLE
rclawlor/move to rsnvim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ checksum = "d6a8f5a1e1be160ce2b669c2c495a34ade6f3a525d4afafd7370c1792070f587"
 dependencies = [
  "log",
  "rmp",
- "rmpv",
+ "rmpv 0.4.7",
  "unix_socket",
 ]
 
@@ -123,15 +123,17 @@ version = "0.1.0"
 dependencies = [
  "lazy_static",
  "neovim-lib",
+ "rmpv 1.3.0",
+ "rsnvim",
  "tracing",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "rmp"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
 dependencies = [
  "byteorder",
  "num-traits",
@@ -148,6 +150,25 @@ dependencies = [
  "rmp",
  "serde",
  "serde_bytes",
+]
+
+[[package]]
+name = "rmpv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58450723cd9ee93273ce44a20b6ec4efe17f8ed2e3631474387bfdecf18bb2a9"
+dependencies = [
+ "num-traits",
+ "rmp",
+]
+
+[[package]]
+name = "rsnvim"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca646d32e397481a6439ab0dff7e118863d298b32e82686f34e884b369496f"
+dependencies = [
+ "rmpv 1.3.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,7 @@ edition = "2021"
 [dependencies]
 lazy_static = "1.4.0"
 neovim-lib = "0.6.1"
+rmpv = "1.3.0"
+rsnvim = "0.1.0"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/lua/regex-railroad/command.lua
+++ b/lua/regex-railroad/command.lua
@@ -31,7 +31,7 @@ end
 ---
 --- @param filename string name of current file
 --- @param text string text containing regular expression
---- @return table 
+--- @return table
 local function regex_text(filename, text)
     local response = vim.api.nvim_call_function(
         "rpcrequest",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
-use neovim_lib::{Neovim, NeovimApi, Session, Value};
+use rmpv::Value;
+use rsnvim::{api::Nvim, handler::RequestHandler};
 use std::{fs::File, sync::Arc};
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 use tracing_subscriber::{self, layer::SubscriberExt};
 
 use crate::{
@@ -19,29 +20,14 @@ pub mod text;
 pub mod test;
 
 
-struct EventHandler {
-    nvim: Neovim,
-    regex_railroad: RegexExtractor,
+struct ReqHandler {
+    regex_railroad: RegexExtractor
 }
 
-impl EventHandler {
-    fn new() -> EventHandler {
-        info!("Creating event handler");
-        let session = match Session::new_parent() {
-            Ok(session) => session,
-            Err(e) => {
-                error!("Couldn't create neovim session {}", e);
-                panic!("Couldn't create neovim session {}", e);
-            }
-        };
-
-        let nvim = Neovim::new(session);
+impl ReqHandler {
+    pub fn new() -> ReqHandler {
         let regex_railroad = RegexExtractor::new();
-
-        EventHandler {
-            nvim,
-            regex_railroad,
-        }
+        ReqHandler { regex_railroad }
     }
 
     /// Retrieve filename and node text from RPC arguments
@@ -54,195 +40,81 @@ impl EventHandler {
         Ok((filename.to_string(), node.to_string()))
     }
 
-    fn recv(&mut self) -> Result<(), Error> {
-        let receiver = self.nvim.session.start_event_loop_channel();
-        info!("Started RPC event loop");
-        for (event, value) in receiver {
-            match Message::from(event) {
-                Message::RegexRailroad => {
-                    // Handle RPC arguments
-                    let (filename, node) = self.parse_rpc_args(value)?;
+    fn regexrailroad(&self, params: Vec<Value>) -> Result<Value, Error> {
+        // Handle RPC arguments
+        let (filename, node) = self.parse_rpc_args(params)?;
 
-                    // Obtain regular expression from received text
-                    let regex = self.regex_railroad.get_regex(&filename, &node)?;
-                    self.send_msg(&regex);
+        // Obtain regular expression from received text
+        let regex = self.regex_railroad.get_regex(&filename, &node)?;
 
-                    // Parse and render regular expression
-                    let mut parser = RegExParser::new(&regex);
-                    let parsed_regex = parser.parse()?;
-                    info!("Parsed regular expression: {:?}", parsed_regex);
+        // Parse and render regular expression
+        let mut parser = RegExParser::new(&regex);
+        let parsed_regex = parser.parse()?;
+        info!("Parsed regular expression: {:?}", parsed_regex);
 
-                    // Generate and render diagram
-                    let diagram = RailroadRenderer::generate_diagram(&parsed_regex)?;
-                    info!("Successfully generated diagram: {:?}", diagram);
-                    let text = RailroadRenderer::render_diagram(&diagram)?;
-                    info!("Successfully rendered diagram");
+        // Generate and render diagram
+        let diagram = RailroadRenderer::generate_diagram(&parsed_regex)?;
+        info!("Successfully generated diagram: {:?}", diagram);
+        let text = RailroadRenderer::render_diagram(&diagram)?;
+        info!("Successfully rendered diagram");
 
-                    // Create neovim buffer and window
-                    let buf = match self.nvim.call_function(
-                        "nvim_create_buf",
-                        vec![Value::Boolean(false), Value::Boolean(true)],
-                    ) {
-                        Ok(buf) => buf,
-                        Err(e) => {
-                            error!("Error creating buffer: {}", e);
-                            panic!();
-                        }
-                    };
-                    let win_opts = Value::Map(vec![
-                        // Increase height and width by 2 for whitespace padding
-                        (
-                            Value::from("width"),
-                            Value::from(text[0].chars().count() + 2),
-                        ),
-                        (Value::from("height"), Value::from(text.len() + 2)),
-                        // TODO: allow styles to be set by the user
-                        (Value::from("style"), Value::from("minimal")),
-                        (Value::from("relative"), Value::from("cursor")),
-                        // Slight offset for readability
-                        (Value::from("row"), Value::from(1)),
-                        (Value::from("col"), Value::from(0)),
-                    ]);
-                    match self.nvim.call_function(
-                        "nvim_open_win",
-                        vec![buf.clone(), Value::Boolean(true), win_opts],
-                    ) {
-                        Ok(win) => {
-                            info!("Opened window with ID {}", win);
-                            win
-                        }
-                        Err(e) => {
-                            error!("Error creating window: {}", e);
-                            panic!();
-                        }
-                    };
+        Ok(Value::Map(vec![
+            (
+                Value::from("text"), 
+                Value::from(text.iter().map(|x| Value::from(x.as_str())).collect::<Vec<Value>>())
+            ),
+            (Value::from("width"), Value::from(text[0].chars().count())),
+            (Value::from("height"), Value::from(text.len()))
+        ]))
+    }
 
-                    match self.nvim.call_function(
-                        "nvim_buf_set_lines",
-                        vec![
-                            buf.clone(),
-                            Value::from(1),
-                            Value::from(-1),
-                            Value::from(true),
-                            text.iter().map(|x| format!(" {} ", x)).collect(),
-                        ],
-                    ) {
-                        Ok(_) => (),
-                        Err(e) => error!("Error setting buffer lines: {}", e),
-                    };
-                }
-                Message::RegexText => {
-                    // Handle RPC arguments
-                    let (filename, node) = self.parse_rpc_args(value)?;
+    fn railroadtext(&self, params: Vec<Value>) -> Result<Value, Error> {
+        // Handle RPC arguments
+        let (filename, node) = self.parse_rpc_args(params)?;
 
-                    // Obtain regular expression from received text
-                    let regex = self.regex_railroad.get_regex(&filename, &node)?;
-                    self.send_msg(&regex);
+        // Obtain regular expression from received text
+        let regex = self.regex_railroad.get_regex(&filename, &node)?;
 
-                    // Parse and render regular expression
-                    let mut parser = RegExParser::new(&regex);
-                    let parsed_regex = parser.parse()?;
-                    info!("Parsed regular expression: {:?}", parsed_regex);
-                    let (text, highlight) = TextRenderer::render_text(&parsed_regex)?;
-                    info!("Successfully rendered text");
+        // Parse and render regular expression
+        let mut parser = RegExParser::new(&regex);
+        let parsed_regex = parser.parse()?;
+        info!("Parsed regular expression: {:?}", parsed_regex);
+        let (text, _highlight) = TextRenderer::render_text(&parsed_regex)?;
+        info!("Successfully rendered text");
 
-                    // Create neovim buffer and window
-                    let buf = match self.nvim.call_function(
-                        "nvim_create_buf",
-                        vec![Value::Boolean(false), Value::Boolean(true)],
-                    ) {
-                        Ok(buf) => buf,
-                        Err(e) => {
-                            error!("Error creating buffer: {}", e);
-                            panic!();
-                        }
-                    };
-                    let win_opts = Value::Map(vec![
-                        // Increase height and width by 2 for whitespace padding
-                        (
-                            Value::from("width"),
-                            Value::from(text.iter().max_by_key(|x| x.len()).unwrap().len() + 2),
-                        ),
-                        (Value::from("height"), Value::from(text.len() + 2)),
-                        // TODO: allow styles to be set by the user
-                        (Value::from("style"), Value::from("minimal")),
-                        (Value::from("relative"), Value::from("cursor")),
-                        // Slight offset for readability
-                        (Value::from("row"), Value::from(1)),
-                        (Value::from("col"), Value::from(0)),
-                    ]);
-                    match self.nvim.call_function(
-                        "nvim_open_win",
-                        vec![buf.clone(), Value::Boolean(true), win_opts],
-                    ) {
-                        Ok(win) => {
-                            info!("Opened window with ID {}", win);
-                            win
-                        }
-                        Err(e) => {
-                            error!("Error creating window: {}", e);
-                            panic!();
-                        }
-                    };
-                    match self.nvim.call_function(
-                        "nvim_buf_set_lines",
-                        vec![
-                            buf.clone(),
-                            Value::from(1),
-                            Value::from(-1),
-                            Value::from(true),
-                            text.iter().map(|x| format!(" {} ", x)).collect(),
-                        ],
-                    ) {
-                        Ok(_) => (),
-                        Err(e) => error!("Error setting buffer lines: {}", e),
-                    };
+        Ok(Value::Map(vec![
+            (
+                Value::from("text"), 
+                Value::from(text.iter().map(|x| Value::from(x.as_str())).collect::<Vec<Value>>())
+            ),
+            (Value::from("width"), Value::from(text[0].chars().count())),
+            (Value::from("height"), Value::from(text.len()))
+        ]))
+    }
+}
 
-                    // Highlight keywords in text
-                    for (line, start, end) in highlight.iter() {
-                        self.nvim
-                            .call_function(
-                                "nvim_buf_add_highlight",
-                                vec![
-                                    buf.clone(),
-                                    Value::from(0),
-                                    Value::from("RegexHighlight"),
-                                    // 0/1 indexing fun
-                                    Value::from(1 + *line),
-                                    Value::from(1 + *start),
-                                    Value::from(1 + *end),
-                                ],
-                            )
-                            .unwrap();
-                    }
-                    info!("Finished");
-                }
-                Message::Unknown(unknown) => {
-                    self.nvim
-                        .command(&format!("echo \"Unknown command: {}\"", unknown))
-                        .unwrap();
-                    warn!("Unknown command: {}", unknown);
-                }
+impl RequestHandler for ReqHandler {
+    fn handle_request(
+            &self,
+            _msgid: u64,
+            method: String,
+            params: Vec<Value>,
+    ) -> Result<Value, rsnvim::error::Error> {
+        match method.as_str() {
+            "regexrailroad" => {
+                info!("RegexRailroad command received");
+                Ok(self.regexrailroad(params).unwrap())
+            },
+            "regextext" => {
+                info!("RegexText command received");
+                Ok(self.railroadtext(params).unwrap())
+            }, 
+
+            unknown => {
+                warn!("Unknown command: {}", unknown);
+                Ok(Value::from(""))
             }
         }
-        Ok(())
-    }
-
-    /// Send message to the command line
-    fn send_msg(&mut self, msg: &String) {
-        self.nvim.command(&format!("echo \"{}\"", msg)).unwrap();
-    }
-
-    /// Echo error to the command line and exit
-    fn send_error(&mut self, error: Error) -> ! {
-        error!("{}", error);
-        self.nvim
-            .command(&format!(
-                "echohl ErrorMsg | echo \"{}\" | echohl None",
-                error
-            ))
-            .unwrap();
-        panic!()
     }
 }
 
@@ -278,13 +150,9 @@ fn main() {
     );
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
-    let mut event_handler = EventHandler::new();
+    let mut nvim = Nvim::from_parent().unwrap();
+    let handler = ReqHandler::new();
+    nvim.start_event_loop(Some(Box::new(handler)), None);
 
-    match event_handler.recv() {
-        Ok(_) => (),
-        Err(e) => {
-            error!("Error: {}", e);
-            event_handler.send_error(e)
-        },
-    }
+    loop {}
 }

--- a/src/railroad/renderer.rs
+++ b/src/railroad/renderer.rs
@@ -1,4 +1,3 @@
-use std::usize;
 use std::iter;
 use tracing::info;
 


### PR DESCRIPTION
- Change from neovim-lib to rsnvim crate
- Use blocking RPC requests rather than RPC notify to allow for more robust error handling